### PR TITLE
Almost deployment ready . . .

### DIFF
--- a/school/src/main/java/com/lambdaschool/school/config/DataSourceConfig.java
+++ b/school/src/main/java/com/lambdaschool/school/config/DataSourceConfig.java
@@ -27,7 +27,7 @@ public class DataSourceConfig
         // H2 = testing
         // PostgreSQL = production
 //        String dbValue = env.getProperty("local.run.db");
-        String dbValue = "POSTGRESQL"; // Trying to get the value from application.properties cause a nullPointerException >.>
+        String dbValue = "POSTGRESQL"; // Trying to get the value from application.properties causes a nullPointerException >.>
 
         if(dbValue.equalsIgnoreCase("POSTGRESQL"))
         {


### PR DESCRIPTION
When I created the `heroku-deployment` branch via IntelliJ, it set `master` as the remote branch. Once I pushed my local `heroku-deployment`, the master updated with all of the changes.

I reverted 6 commits I made in order to set `master` back to what it was since the last merge. However, because master has the same commits that `heroku-deployment` does, GitHub thinks that master is 6 commits _ahead_ of the heroku-deployment branch. (Those 6 commits are all revert commits, to reverse the accidental commits I didn't want the master branch to have.)

Right now, GitHub thinks that heroku-deployment is behind master because of this . . .

Good news: the `heroku-deployment` branch has all of the good code for sure. Merging it properly into `master` might be tough, but it should be doable.